### PR TITLE
Include jinja2 templates in the build artifact

### DIFF
--- a/.cookiecutter/includes/setup.cfg
+++ b/.cookiecutter/includes/setup.cfg
@@ -1,0 +1,4 @@
+
+[options.package_data]
+pyramid_googleauth =
+    templates/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,3 +42,7 @@ ignore =
 
     # Bare except. PyLint finds these for us so we don't need pycodestyle to.
     E722,
+
+[options.package_data]
+pyramid_googleauth =
+    templates/*


### PR DESCRIPTION
Previous commit removed MANIFEST which included templates as part of the
build.

Using a different mechanism here that can be specified directly in
setup.cfg

https://setuptools.pypa.io/en/latest/userguide/datafiles.html#package-data


# Testing 

- On checkmate's repo checkout the branch `dependabot/pip/pyramid-googleauth-1.0.4` 
- One of the functional tests will fail
```
.tox/functests/bin/pytest tests/functional/checkmate/views/ui/admin_test
```

- Install this version of pyramid-googleauth
```
.tox/functests/bin/pip install -e /home/marcos/hypo/pyramid-googleauth
```

- Run the test again and it will pass this time.