### PR TITLE
Change to HTTPS for the devdata clone URL

### DIFF
--- a/bin/make_devdata
+++ b/bin/make_devdata
@@ -12,7 +12,7 @@ if __name__ == "__main__":
                 "clone",
                 "--depth",
                 "1",
-                "git@github.com:hypothesis/devdata.git",
+                "https://github.com/hypothesis/devdata.git",
                 git_dir,
             ]
         )


### PR DESCRIPTION
The easiest way to set up Git->GitHub.com authentication nowadays is by
installing [GitHub CLI](https://cli.github.com/), running
[gh auth login](https://cli.github.com/manual/gh_auth_login), and
answering "Yes" (the default) when it asks "Authenticate Git with your
GitHub credentials?". By default this will set up authentication for
HTTPS git clone URLs but not SSH ones so `make devdata` will fail with
an authentication error because it tries to clone the private devdata
repo using the SSH clone URL.

Fix this by changing the devdata clone URL to the HTTPS one.
