### PR TITLE
Insert `"pypi": "yes"` into `cookiecutter.json`

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -23,6 +23,7 @@
     "__entry_point": "pyramid-googleauth",
     "__github_url": "https://github.com/hypothesis/pyramid-googleauth",
     "__pypi_url": "https://pypi.org/project/pyramid-googleauth",
-    "__copyright_year": "2022"
+    "__copyright_year": "2022",
+    "pypi": "yes"
   }
 }


### PR DESCRIPTION
This is needed to prevent the cookiecutter from removing the PyPI support from this project now that PyPI is optional. See: https://github.com/hypothesis/cookiecutters/pull/104
