### PR TITLE
Avoid a pylint false-positive warning

### DIFF
--- a/tests/unit/pyramid_googleauth/views_test.py
+++ b/tests/unit/pyramid_googleauth/views_test.py
@@ -130,7 +130,7 @@ class TestLogout:
 
         response = logout(sentinel.context, pyramid_request)
 
-        assert response.location == Any.url.containing_query(
+        assert response.location == Any.url().containing_query(
             {"hint": "staff@hypothes.is"}
         )
 


### PR DESCRIPTION
Pylint is confused by the crazy stuff that `h-matchers`'s "fluent
entrypoint" decorator does in order to enable `Any.list.containing(...)`
instead of having to write `Any.list().containing(...)`.
